### PR TITLE
Natoms and nreplicas

### DIFF
--- a/eggs-19/005/nest.yml
+++ b/eggs-19/005/nest.yml
@@ -6,6 +6,7 @@ version: 2.5
 contributor: Gabriella Heller 
 doi: 10.1016/j.jmb.2017.07.016 
 date: 2019-04-20
+nreplicas: 2
 plumed_input:
   - cmyc_alone/plumed/plumed_master.dat
   - cmyc_and_10058_F4/plumed/plumed_master.dat

--- a/eggs-19/010/nest.yml
+++ b/eggs-19/010/nest.yml
@@ -7,9 +7,11 @@ contributor: Carlo Camilloni
 doi: 10.1016/j.jmb.2018.10.024 
 date: 2019-04-16
 plumed_input:
-  - r108a/plumed-mm.dat
+  - path: r108a/plumed-mm.dat
+    nreplicas: 2
   - r108a/plumed-orient.dat
-  - wt/plumed-mm.dat
+  - path: wt/plumed-mm.dat
+    nreplicas: 2
   - wt/plumed-orient.dat
 instructions: >
   this is a metadynamic metainference calculation using residual dipolar coupling to infere

--- a/eggs-19/012/nest.yml
+++ b/eggs-19/012/nest.yml
@@ -7,13 +7,12 @@ contributor: Carlo Camilloni
 doi: 10.1107/S1600576719002450
 date: 2019-04-17
 plumed_input:
-  - Protein-RNA/plumed-main.dat
-  - Protein-DNA/plumed-main.dat
+  - path: Protein-RNA/plumed-main.dat
+    natoms: 103421
+  - path: Protein-DNA/plumed-main.dat
+    natoms: 120254
 instructions: >
   this is a metainference calculation using SAXS for structure refinement. In particular instead than 
   calculting SAXS using all the atoms we first maps them on martini beads using CENTER and then we 
   employ the structure factors parameterised in the paper to efficiently calculate SAXS. The same structure
   factors can be directly used on Martini simulations
-natoms: 
-  - 103421
-  - 120254

--- a/nest.py
+++ b/nest.py
@@ -235,10 +235,14 @@ for path in sorted(pathlist, reverse=True, key=lambda m: str(m)):
 
         if not "plumed_input" in config:
             config["plumed_input"]=sorted(pathlib.Path('.').glob('**/plumed*.dat'))
-            config["plumed_input"]=[str(v) for v in config["plumed_input"]]
+            config["plumed_input"]=[ {"path":str(v)} for v in config["plumed_input"]]
         else:
-            config["plumed_input"]=[root+"/"+str(v) for v in config["plumed_input"]]
-        print(config)
+            conf=config["plumed_input"]
+            for k in range(len(conf)):
+                if not isinstance(conf[k],dict):
+                    conf[k]={"path":conf[k]}
+            for k in range(len(conf)):
+                conf[k]["path"]=root+"/"+str(conf[k]["path"])
 
         egg_id=path[5:7] + "." + path[8:11]
 
@@ -260,19 +264,17 @@ for path in sorted(pathlist, reverse=True, key=lambda m: str(m)):
             print("| File     | Declared compatibility | Compatible with |  ", file=o) 
             print("|:--------:|:---------:|:--------:|  ", file=o)
 
-        k=0
         for file in config["plumed_input"]:
-# in principle returns the list of produced files, not used yet:
-            if not "natoms" in config:
+            if not "natoms" in file:
                 natoms = str(100000)
             else:
-                natoms = str(config["natoms"][k])
+                natoms = str(file["natoms"])
 
-            plumed_format(file,header="**Project ID:** [plumeDnest:" + egg_id+"]({{ '/' | absolute_url }}" + path + ")  \n")
-            success=plumed_input_test("plumed",file,natoms)
-            success_master=plumed_input_test("plumed_master",file,natoms)
-            add_readme(file, str(config["version"]) , (os.environ["PLUMED_LATEST_VERSION"],"master"), (success,success_master),("plumed","plumed_master"))
-            k=k+1
+# in principle returns the list of produced files, not used yet:
+            plumed_format(file["path"],header="**Project ID:** [plumeDnest:" + egg_id+"]({{ '/' | absolute_url }}" + path + ")  \n")
+            success=plumed_input_test("plumed",file["path"],natoms)
+            success_master=plumed_input_test("plumed_master",file["path"],natoms)
+            add_readme(file["path"], str(config["version"]) , (os.environ["PLUMED_LATEST_VERSION"],"master"), (success,success_master),("plumed","plumed_master"))
 
         # print instructions, if present
         with open("README.md","a") as o:


### PR DESCRIPTION
@maxbonomi @carlocamilloni I would like to merge this. I implemented the possibility to control the number of replicas (default is 0, that implies not to use mpiexec).

I changed a bit Carlo's implementation to control number of atoms (number of replicas is done in the same way). Now you can do:
````
url: ...
natoms: 100
````
to change all input files
````
url: ...
plumed_input:
  - first.dat
  - path: second.dat
    natoms: 100
````
to change only the number of atoms for the second file. In practice, for each input file, if it is a string I interpret it as the path, if it is a dictionary I allow one to provide separately path, natoms, and nreplicas.

I think I also fixed the eggs that needed special treatments (005 and 010) 