### PR TITLE
Toward v2.10

### DIFF
--- a/.ci/install.plumed
+++ b/.ci/install.plumed
@@ -8,19 +8,17 @@ version=""
 repo=https://github.com/plumed/plumed2.git
 program_name=plumed
 
-for opt; do
-  case "$opt" in
-  version=*) version="${opt#version=}" ;;
-  suffix=*)
-    suffix="--program-suffix=${opt#suffix=}"
-    program_name="plumed${opt#suffix=}"
-    ;;
-  repo=*) repo="${opt#repo=}" ;;
-  *)
-    echo "unknown option $opt"
-    exit 1
-    ;;
-  esac
+for opt
+do
+case "$opt" in
+  (version=*) version="${opt#version=}" ;;
+  (suffix=*)
+     suffix="--program-suffix=${opt#suffix=}"
+     program_name="plumed${opt#suffix=}"
+   ;;
+  (repo=*) repo="${opt#repo=}" ;;
+  (*) echo "unknown option $opt" ; exit 1 ;;
+esac
 done
 
 cd "$(mktemp -dt plumed.XXXXXX)"
@@ -28,7 +26,7 @@ cd "$(mktemp -dt plumed.XXXXXX)"
 git clone $repo
 cd plumed2
 
-if [ -n "$version" ]; then
+if [ -n "$version" ] ; then
   echo "installing plumed $version"
 else
   version=$(git tag --sort=-version:refname | grep '^v2\.[0-9][0-9]*\.[0-9][0-9]*' | head -n 1)
@@ -39,19 +37,20 @@ git checkout $version
 
 hash=$(git rev-parse HEAD)
 
-if test -f $HOME/opt/lib/$program_name/$hash; then
+if test -f $HOME/opt/lib/$program_name/$hash
+then
   echo "ALREADY AVAILABLE, NO NEED TO REINSTALL"
 else
 
-  rm -fr $HOME/opt/lib/$program_name
-  rm -fr $HOME/opt/bin/$program_name
-  rm -fr $HOME/opt/include/$program_name
-  rm -fr $HOME/opt/lib/lib$program_name.so*
+rm -fr $HOME/opt/lib/$program_name
+rm -fr $HOME/opt/bin/$program_name
+rm -fr $HOME/opt/include/$program_name
+rm -fr $HOME/opt/lib/lib$program_name.so*
 
-  ./configure --prefix=$HOME/opt --enable-modules=all --enable-boost_serialization --enable-fftw $suffix --enable-libtorch LDFLAGS=-Wl,-rpath,$LD_LIBRARY_PATH
-  make -j 5
-  make install
+./configure --prefix=$HOME/opt  --enable-modules=all --enable-boost_serialization --enable-fftw $suffix --enable-libtorch LDFLAGS=-Wl,-rpath,$LD_LIBRARY_PATH
+make -j 5
+make install
 
-  touch $HOME/opt/lib/$program_name/$hash
+touch $HOME/opt/lib/$program_name/$hash
 
 fi

--- a/.ci/install.plumed
+++ b/.ci/install.plumed
@@ -8,17 +8,19 @@ version=""
 repo=https://github.com/plumed/plumed2.git
 program_name=plumed
 
-for opt
-do
-case "$opt" in
-  (version=*) version="${opt#version=}" ;;
-  (suffix=*)
-     suffix="--program-suffix=${opt#suffix=}"
-     program_name="plumed${opt#suffix=}"
-   ;;
-  (repo=*) repo="${opt#repo=}" ;;
-  (*) echo "unknown option $opt" ; exit 1 ;;
-esac
+for opt; do
+  case "$opt" in
+  version=*) version="${opt#version=}" ;;
+  suffix=*)
+    suffix="--program-suffix=${opt#suffix=}"
+    program_name="plumed${opt#suffix=}"
+    ;;
+  repo=*) repo="${opt#repo=}" ;;
+  *)
+    echo "unknown option $opt"
+    exit 1
+    ;;
+  esac
 done
 
 cd "$(mktemp -dt plumed.XXXXXX)"
@@ -26,10 +28,10 @@ cd "$(mktemp -dt plumed.XXXXXX)"
 git clone $repo
 cd plumed2
 
-if [ -n "$version" ] ; then
+if [ -n "$version" ]; then
   echo "installing plumed $version"
 else
-  version=$(git tag --sort=-creatordate | grep '^v2\.[0-9][0-9]*\.[0-9][0-9]*' | head -n 1 )
+  version=$(git tag --sort=-version:refname | grep '^v2\.[0-9][0-9]*\.[0-9][0-9]*' | head -n 1)
   echo "installing latest stable plumed $version"
 fi
 
@@ -37,20 +39,19 @@ git checkout $version
 
 hash=$(git rev-parse HEAD)
 
-if test -f $HOME/opt/lib/$program_name/$hash
-then
+if test -f $HOME/opt/lib/$program_name/$hash; then
   echo "ALREADY AVAILABLE, NO NEED TO REINSTALL"
 else
 
-rm -fr $HOME/opt/lib/$program_name
-rm -fr $HOME/opt/bin/$program_name
-rm -fr $HOME/opt/include/$program_name
-rm -fr $HOME/opt/lib/lib$program_name.so*
+  rm -fr $HOME/opt/lib/$program_name
+  rm -fr $HOME/opt/bin/$program_name
+  rm -fr $HOME/opt/include/$program_name
+  rm -fr $HOME/opt/lib/lib$program_name.so*
 
-./configure --prefix=$HOME/opt  --enable-modules=all --enable-boost_serialization --enable-fftw $suffix --enable-libtorch LDFLAGS=-Wl,-rpath,$LD_LIBRARY_PATH
-make -j 5
-make install
+  ./configure --prefix=$HOME/opt --enable-modules=all --enable-boost_serialization --enable-fftw $suffix --enable-libtorch LDFLAGS=-Wl,-rpath,$LD_LIBRARY_PATH
+  make -j 5
+  make install
 
-touch $HOME/opt/lib/$program_name/$hash
+  touch $HOME/opt/lib/$program_name/$hash
 
 fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,8 @@ jobs:
         ccache -s
         .ci/install.libtorch
         # version=master or version=f123f12f3 to select a specific version
-        # pick newest release branch (alphabetic, will fail at v2.10)
-        CXX="mpic++" .ci/install.plumed version="$(cd plumed2.git ; git branch | sed "s/^ *//" | grep '^v2\.[0-9]$' | tail -n 1)" repo=$PWD/plumed2.git
+        # pick newest release branch (--sort=-version:refname sorts by versions)
+        CXX="mpic++" .ci/install.plumed version="$(cd plumed2.git ; git branch --sort=-version:refname | sed "s/^ *//" | grep '^v2\.[0-9][0-9]*$' | head -n 1)" repo=$PWD/plumed2.git
         # GB: in addition, we install master version as plumed_master
         CXX="mpic++" .ci/install.plumed version=master suffix=_master repo=$PWD/plumed2.git
         ccache -s


### PR DESCRIPTION
I changed ho the branches (and the tags) are sorted by git, and how grep matches the version number

I tried this on a dummy repo:
```bash
for num in $(seq 22); do
  v=v2.$num
  echo "$v" >"$v"
  git checkout -b "$v"
  git add "$v"
  git commit -am "$v"
done
git branch --sort=-version:refname | sed "s/^ *//" | grep '^v2\.[0-9][0-9]*$' | head -n 1
```

at the ends returned v2.21 as expected