### PR TITLE
Added functionality to nest to make the eggs searchable by the names …

### DIFF
--- a/browse.md
+++ b/browse.md
@@ -8,9 +8,9 @@ If you are a contributor, you can check if your eggs are still compatible with t
 -->
 
 {:#browse-table .display}
-| plumID | Name | Category | Keywords | Contributor |
-|:--------:|:--------:|:---------:|:---------:|:---------:|
-{% for item in site.data.eggs %}| [{{ item.id }}]({{ item.path }}) | {{ item.name }} | {{ item.category }} | {{ item.keywords }} | {{ item.contributor | split: " " | last}} {{ item.contributor | split: " " | first | slice: 0}}. |
+| plumID | Name | Category | Keywords | Contributor | Actions |
+|:--------:|:--------:|:---------:|:---------:|:---------:|:---------:|
+{% for item in site.data.eggs %}| [{{ item.id }}]({{ item.path }}) | {{ item.name }} | {{ item.category }} | {{ item.keywords }} | {{ item.contributor | split: " " | last}} {{ item.contributor | split: " " | first | slice: 0}}. | {{ item.actions }} |
 {% endfor %}
 
 <script>
@@ -20,6 +20,9 @@ var table = $('#browse-table').DataTable({
   language: { search: '', searchPlaceholder: "Search project..." },
   buttons: [
         'copy', 'excel', 'pdf'
+  ],
+  "columnDefs": [ 
+     { "targets": 5, "visible": false }
   ],
   "order": [[ 0, "desc" ]]
   });

--- a/nest.py
+++ b/nest.py
@@ -83,7 +83,7 @@ def get_short_name_end(lname, length):
     else: sname = lname
     return sname
 
-def plumed_format(source,tested,status,exe,global_header=None,header=None):
+def plumed_format(source,tested,status,exe,actions,global_header=None,header=None):
     """ Format plumed input file.
 
     source: path to master input file
@@ -107,7 +107,7 @@ def plumed_format(source,tested,status,exe,global_header=None,header=None):
                  print(header,file=o)
             # Read in the input file and get the rendered html
             lines = f.read()
-            html = get_html( lines, source, os.path.basename(source), tested, status, exe )
+            html = get_html( lines, source, os.path.basename(source), tested, status, exe, actions=actions )
             # make sure Jekyll does not interfere with format
             print("{% raw %}",file=o)
             print( html, file=o )
@@ -277,6 +277,7 @@ def process_egg(path,eggdb=None):
 
         # count number of failing tests
         nfail=0; nfailm=0
+        actions = set({})
         for file in config["plumed_input"]:
 
             if "natoms" in file:
@@ -336,7 +337,7 @@ def process_egg(path,eggdb=None):
                 if int(re.sub("[^0-9].*","",re.sub("^2\\.","",stable_version))) < int(re.sub("[^0-9].*","",re.sub("^2\\.","",plumed_version))):
                    success="ignore"
             # Generate the plumed input 
-            plumed_format(file["path"], ("v"+ stable_version,"master"), (success,success_master), ("plumed","plumed_master"), global_header=global_header,header=header)
+            plumed_format(file["path"], ("v"+ stable_version,"master"), (success,success_master), ("plumed","plumed_master"), actions, global_header=global_header,header=header)
             add_readme(file["path"], ("v"+ stable_version,"master"), (success,success_master),("plumed","plumed_master"),has_load,has_custom)
 
         # print instructions, if present
@@ -386,6 +387,8 @@ def process_egg(path,eggdb=None):
         print("  nfail: " + str(nfail),file=eggdb)
         print("  nfailm: " + str(nfailm),file=eggdb)
         print("  preprint: " + str(prep),file=eggdb)
+        astr = ' '.join(actions)
+        print("  actions: " + astr,file=eggdb)
     eggdb.flush()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added functionality to make the nest searchable by the actions used in the inputs.

This functionality works as follows:

(1) Whenever PlumedToHTML::get_html is called it adds the names of the actions that are found in the plumed input to a python set that is passed back to the calling code. 
(2) An empty set is created when process_egg is called.  This empty set is then passed to PlumedToHTML::get_html every time a plumed input is called.  At the end of process_egg this set lists all the actions that have been used in the egg. 
(3) The actions that are used within the egg are put in a column of the table that appears on the browse page.  This column is invisible but it is seachable.

You can see how this all works on the test site, which I pushed this branch to earlier today.