### PR TITLE
Sort by plumID in dropdown

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -37,11 +37,12 @@ __Please note that:__
 
 Fields marked with "<sup>*</sup>" are optional  
 
+{% assign sorted_eggs = site.data.eggs | sort: "id" | reverse %}
 <form class="wj-contact" method="POST" action="https://formspree.io/plumed.nest@gmail.com">
   <table>
     <tr>
       <td><label for="id">plumID</label></td>
-      <td width="600"><select id="id" type="texy" name="plumID"><option>new (plumID to be assigned)</option>{% for item in site.data.eggs %}<option>{{ item.id }}:{{ item.shortname }}</option>{% endfor %} required</select> </td>
+      <td width="600"><select id="id" type="texy" name="plumID"><option>new (plumID to be assigned)</option>{% for item in sorted_eggs %}<option>{{ item.id }}:{{ item.shortname }}</option>{% endfor %} required</select> </td>
     </tr>
     <tr>  
       <td><label for="name">Project name</label></td>


### PR DESCRIPTION
In principle, one can use the web form to update an existing egg (at least, the instructions suggest that). However, the order that the eggs are listed in the `<select>` is not well-defined. This PR sorts them in reverse order of plumID (expecting that more recent submissions are more likely to need to be updated). Hopefully, this makes it easier to find older eggs for resubmission/update!

Current site:

![image](https://github.com/plumed-nest/plumed-nest/assets/8178546/f1d6d111-1e1f-4f2b-90e6-01c506e63e99)

After this change:

![image](https://github.com/plumed-nest/plumed-nest/assets/8178546/2a21ace9-5c9b-4a10-b345-0b28378dcc2f)