### PR TITLE
Search the nest from the URL

### DIFF
--- a/browse.md
+++ b/browse.md
@@ -29,5 +29,10 @@ var table = $('#browse-table').DataTable({
 $('#browse-table-searchbar').keyup(function () {
   table.search( this.value ).draw();
   });
+  hu = window.location.search.substring(1);
+  searchfor = hu.split("=");
+  if( searchfor[0]=="search" ) {
+      table.search( searchfor[1] ).draw();
+  }
 });
 </script>

--- a/contribute.md
+++ b/contribute.md
@@ -30,6 +30,12 @@ __Please note that:__
 * PLUMED-NEST will not host your archive, so make sure the indicated URL remains accessible. More info about where to host your contribution can be found [here](https://github.com/plumed-nest/plumed-nest/blob/master/README.md#zip-info).
 * PLUMED-NEST will not test your execution scripts, but only the compatibility of the PLUMED input files provided.
 
+Lastly, note that if you want to a link to the content that you have contributed to plumed nest on your personal website you can use a url like the one below:
+
+````
+https://www.plumed-nest.org/browse.html?search=yourname
+````
+
 <center>
 <p><b>Questions related to the submission to PLUMED-NEST can be directed to:</b></p>
 <p><b><a href="mailto:plumed.nest@gmail.com">plumed.nest@gmail.com</a></b></p>


### PR DESCRIPTION
Hi @maxbonomi 

This is a little feature that I have added that I think will be quite useful.  The idea is that you can create a link to the browse page that will automatically populate the search bar.  You can thus create a link like [this one](https://plumed-school.github.io/browse.html?search=bonomi) that lists all the tutorials that you have written for the plumed-tutorials pages.

I'd like to use this feature to create links in the manual that say [here are all the tutorials that show you how to use the PCA action](https://plumed-school.github.io/browse.html?search=pca).  I think using links like this is the best way to provide this functionality as it will then be easy to maintain.