### PR TITLE
Inputs searchable by modules, fancy new input file formats and use-load badge not triggered by load in comment

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -71,14 +71,14 @@
         }
       }
       var redpath="";
-      function showPath(eg,name) {
+      function showPath(eg,name,valfield,color) {
         var i; var y = document.getElementsByName(redpath);
-        for (i=0; i < y.length; i++ ) { y[i].style.color="black"; }
+        for (i=0; i < y.length; i++ ) { y[i].style.color=""; }
         var x = document.getElementsByName(name); redpath=name;
-        for (i = 0; i < x.length; i++) { x[i].style.color="red"; }
+        for (i = 0; i < x.length; i++) { x[i].style.color=color; }
         var valid="value_details_".concat(eg);
         var valueField = document.getElementById(valid);
-        var dataField = document.getElementById(name);
+        var dataField = document.getElementById(valfield);
         valueField.innerHTML = dataField.innerHTML;
       }
       function toggleDisplay(name) {

--- a/browse.md
+++ b/browse.md
@@ -8,9 +8,9 @@ If you are a contributor, you can check if your eggs are still compatible with t
 -->
 
 {:#browse-table .display}
-| plumID | Name | Category | Keywords | Contributor | Actions |
-|:--------:|:--------:|:---------:|:---------:|:---------:|:---------:|
-{% for item in site.data.eggs %}| [{{ item.id }}]({{ item.path }}) | {{ item.name }} | {{ item.category }} | {{ item.keywords }} | {{ item.contributor | split: " " | last}} {{ item.contributor | split: " " | first | slice: 0}}. | {{ item.actions }} |
+| plumID | Name | Category | Keywords | Contributor | Actions | Modules |
+|:--------:|:--------:|:---------:|:---------:|:---------:|:---------:|:---------:|
+{% for item in site.data.eggs %}| [{{ item.id }}]({{ item.path }}) | {{ item.name }} | {{ item.category }} | {{ item.keywords }} | {{ item.contributor | split: " " | last}} {{ item.contributor | split: " " | first | slice: 0}}. | {{ item.actions }} | {{ item.modules }} |
 {% endfor %}
 
 <script>
@@ -22,7 +22,8 @@ var table = $('#browse-table').DataTable({
         'copy', 'excel', 'pdf'
   ],
   "columnDefs": [ 
-     { "targets": 5, "visible": false }
+     { "targets": 5, "visible": false },
+     { "targets": 6, "visible": false }
   ],
   "order": [[ 0, "desc" ]]
   });

--- a/nest.py
+++ b/nest.py
@@ -326,7 +326,6 @@ def process_egg(path,action_counts,plumed_syntax,eggdb=None):
             header+= "[stderr]("+ re.sub(".*/","",file["path"]) +".plumed_master.stderr)  \n"
 
 # in principle returns the list of produced files, not used yet:
-            with open(file["path"]) as f : has_load = "LOAD" in f.read()
             has_custom = re.match(".*-mod",plumed_version)
             
             success=test_plumed("plumed",file["path"],header=global_header)
@@ -341,7 +340,7 @@ def process_egg(path,action_counts,plumed_syntax,eggdb=None):
                    success="ignore"
             # Generate the plumed input 
             plumed_format(file["path"], ("v"+ stable_version,"master"), (success,success_master), ("plumed","plumed_master"), actions, usejson=(not success_master), global_header=global_header,header=header)
-            add_readme(file["path"], ("v"+ stable_version,"master"), (success,success_master),("plumed","plumed_master"),has_load,has_custom)
+            add_readme(file["path"], ("v"+ stable_version,"master"), (success,success_master),("plumed","plumed_master"),("LOAD" in actions),has_custom)
 
         # print instructions, if present
         with open("README.md","a") as o:

--- a/nest.py
+++ b/nest.py
@@ -146,7 +146,7 @@ def cd(newdir):
     finally:
         os.chdir(prevdir)
 
-def process_egg(path,action_counts,eggdb=None):
+def process_egg(path,action_counts,plumed_syntax,eggdb=None):
 
     if not eggdb:
         eggdb=sys.stdout
@@ -389,10 +389,18 @@ def process_egg(path,action_counts,eggdb=None):
         print("  nfail: " + str(nfail),file=eggdb)
         print("  nfailm: " + str(nfailm),file=eggdb)
         print("  preprint: " + str(prep),file=eggdb)
+        modules = set()
         for a in actions :
+            if a in plumed_syntax.keys() :
+               try :
+                 modules.add( plumed_syntax[a]["module"] )
+               except : 
+                 raise Exception("could not find module for action " + a)
             if a in action_counts.keys() : action_counts[a] += 1
         astr = ' '.join(actions)
         print("  actions: " + astr,file=eggdb)
+        modstr = ' '.join(modules)
+        print("  modules: " + modstr, file=eggdb)
     eggdb.flush()
 
 if __name__ == "__main__":
@@ -446,7 +454,7 @@ if __name__ == "__main__":
 
             if k%nreplicas==replica :
                start_time = time.perf_counter() 
-               process_egg(re.sub("nest.yml$","",str(path)),action_counts,eggdb)
+               process_egg(re.sub("nest.yml$","",str(path)),action_counts,plumed_syntax,eggdb)
                end_time = time.perf_counter()
                print(f"Egg took {end_time - start_time:0.4f} seconds")
             k = k + 1 

--- a/nest.py
+++ b/nest.py
@@ -85,7 +85,7 @@ def get_short_name_end(lname, length):
     else: sname = lname
     return sname
 
-def plumed_format(source,tested,status,exe,actions,global_header=None,header=None):
+def plumed_format(source,tested,status,exe,actions,usejson=False,global_header=None,header=None):
     """ Format plumed input file.
 
     source: path to master input file
@@ -109,7 +109,7 @@ def plumed_format(source,tested,status,exe,actions,global_header=None,header=Non
                  print(header,file=o)
             # Read in the input file and get the rendered html
             lines = f.read()
-            html = get_html( lines, source, os.path.basename(source), tested, status, exe, actions=actions )
+            html = get_html( lines, source, os.path.basename(source), tested, status, exe, usejson=usejson, maxchecks=100, actions=actions )
             # make sure Jekyll does not interfere with format
             print("{% raw %}",file=o)
             print( html, file=o )
@@ -331,7 +331,8 @@ def process_egg(path,action_counts,plumed_syntax,eggdb=None):
             
             success=test_plumed("plumed",file["path"],header=global_header)
             if(success!=0 and success!="custom"): nfail+=1
-            success_master=test_plumed("plumed_master",file["path"],header=global_header)
+            plumed_file = os.path.basename(file["path"])
+            success_master=test_plumed("plumed_master",file["path"],header=global_header, printjson=True )
             if(success_master!=0 and success_master!="custom"): nfailm+=1
             # Find the stable version 
             stable_version=subprocess.check_output('plumed info --version', shell=True).decode('utf-8').strip()
@@ -339,7 +340,7 @@ def process_egg(path,action_counts,plumed_syntax,eggdb=None):
                 if int(re.sub("[^0-9].*","",re.sub("^2\\.","",stable_version))) < int(re.sub("[^0-9].*","",re.sub("^2\\.","",plumed_version))):
                    success="ignore"
             # Generate the plumed input 
-            plumed_format(file["path"], ("v"+ stable_version,"master"), (success,success_master), ("plumed","plumed_master"), actions, global_header=global_header,header=header)
+            plumed_format(file["path"], ("v"+ stable_version,"master"), (success,success_master), ("plumed","plumed_master"), actions, usejson=(not success_master), global_header=global_header,header=header)
             add_readme(file["path"], ("v"+ stable_version,"master"), (success,success_master),("plumed","plumed_master"),has_load,has_custom)
 
         # print instructions, if present


### PR DESCRIPTION
Hello @maxbonomi 

This is a combination of three new features for the nest:

1. I have made it possible to search the nest by module name.  You can thus find inputs that use actions in the eds module only.  You can also create [a link](https://www.plumed-nest.org/test-site/browse.html?search=eds) to all the nest inputs that use the eds module.
2. I now decide whether to show the has load badge with the following command `"LOAD" in actions` where actions is the list of actions that were found in the plumed input by PlumedToHTML.  You thus should not get the LOAD badge shown if you have LOAD in a comment.  You can see how load in a comment gets the load badge in the current version of the nest [here](https://www.plumed-nest.org/eggs/24/012/) and that this is fixed in [the new version](https://www.plumed-nest.org/test-site/eggs/24/012/).
3. There are a bunch of new features in PlumedToHTML that are now being used here.  If you look at the input here:

https://www.plumed-nest.org/test-site/eggs/21/013/data/ch4-base/asymm-sample/plumed.inp.html

You can see some of the new things that it can do.  Click on the expand shortcuts link in the COORDINATIONNUMBER command.  Then click on the labels of actions.  Different types of object are identified with colour coded labels when clicked on.  I think this is cool.

Currently, I have 274 failures with master on this branch and only 213 on the master branch.  I thus wouldn't recommending merging just yet.  I think many of these problems can be resolved.  A number are due to issues with the documentation generating stuff in PLUMED so it should be possible to fix them.  I thought I would create this PR now so that the new nest code is at least on Github.